### PR TITLE
Add option vim_markdown_preview_temp_delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Vim Markdown Preview
     - [Hotkey](#hotkey)
     - [Browser](#browser)
     - [Temp File](#temp)
+    - [Temp Delay](#tempdelay)
     - [Github Flavoured Markdown](#github)
     - [Markdown.pl](#perl)
     - [Pandoc](#pandoc)
@@ -128,6 +129,20 @@ Default: `0`
 Example: Remove the rendered preview.
 ```vim
 let vim_markdown_preview_temp_file=1
+```
+
+<a name='tempdelay'></a>
+### The `vim_markdown_preview_temp_delay` option
+
+The temp file might get deleted too early, when your browser needs a longer time to rendered html file. The browser then shows an errors. This option let's you increase the delay between preview invocation and temp file deletion.
+
+Default: `200m`
+
+Examples: Sleep for 2 seconds
+```vim
+let vim_markdown_preview_temp_delay='2'
+" or in milliseconds
+let vim_markdown_preview_temp_delay='2000m'
 ```
 
 <a name='github'></a>

--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -34,6 +34,10 @@ if !exists("g:vim_markdown_preview_temp_file")
   let g:vim_markdown_preview_temp_file = 0
 endif
 
+if !exists("g:vim_markdown_preview_temp_delay")
+  let g:vim_markdown_preview_temp_delay = '200m'
+endif
+
 if !exists("g:vim_markdown_preview_toggle")
   let g:vim_markdown_preview_toggle = 0
 endif
@@ -105,7 +109,7 @@ function! Vim_Markdown_Preview()
   endif
 
   if g:vim_markdown_preview_temp_file == 1
-    sleep 200m
+    execute 'sleep ' . g:vim_markdown_preview_temp_delay
     call system('rm /tmp/vim-markdown-preview.html')
   endif
 endfunction
@@ -159,7 +163,7 @@ function! Vim_Markdown_Preview_Local()
   endif
 
   if g:vim_markdown_preview_temp_file == 1
-    sleep 200m
+    execute 'sleep ' . g:vim_markdown_preview_temp_delay
     call system('rm vim-markdown-preview.html')
   endif
 endfunction


### PR DESCRIPTION
The delay between preview invocation and temp file deletion becomes
configurable and user having slower browser can still make use of the
automatic preview.

* New option vim_markdown_preview_temp_delay
* Left default at 200m
* Update README.md accordingly
